### PR TITLE
fix: switch to linux arm64 and docker in docker

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -108,18 +108,18 @@ jobs:
         run: |
           docker pull ${{ steps.tags.outputs.docker_registry }}/base:latest || true
 
+          ADDITIONAL_BUILD_COMMANDS="--platform=linux/amd64"
+          if [ ${{ github.ref == 'refs/heads/main' }} = "true" ]; then
+            ADDITIONAL_BUILD_COMMANDS="--platform=linux/amd64,linux/arm64 --push"
+          fi
+
           devcontainer build \
-            --platform=linux/amd64 \
+            ${ADDITIONAL_BUILD_COMMANDS} \
             --image-name=${{ steps.tags.outputs.docker_registry }}/base:${{ steps.tags.outputs.tag }} \
             --image-name=${{ steps.tags.outputs.docker_registry }}/base:latest \
             --workspace-folder=images/base
 
-          if [ ${{ github.ref == 'refs/heads/main' }} = "true" ]; then
-            echo "Pushing images"
-
-            docker push ${{ steps.tags.outputs.docker_registry }}/base:${{ steps.tags.outputs.tag }}
-            docker push ${{ steps.tags.outputs.docker_registry }}/base:latest
-          else
+          if [ ${{ github.ref == 'refs/heads/main' }} = "false" ]; then
             echo "Saving base image"
             docker save ${{ steps.tags.outputs.docker_registry }}/base:latest -o base.tar.gz
           fi
@@ -180,9 +180,12 @@ jobs:
 
       - name: Build Dev Container
         run: |
+          ADDITIONAL_BUILD_COMMANDS="--platform=linux/amd64"
           if [ ${{ github.ref == 'refs/heads/main' }} = "true" ]; then
             echo "Pulling image from registry"
             docker pull ${{ needs.base.outputs.docker_registry }}/base
+
+            ADDITIONAL_BUILD_COMMANDS="--platform=linux/amd64,linux/arm64 --push"
           else
             echo "Importing image from cache"
             docker import base.tar.gz ${{ needs.base.outputs.docker_registry }}/base
@@ -191,14 +194,7 @@ jobs:
           docker pull ${{ needs.base.outputs.docker_registry }}/${{ steps.tags.outputs.name }}:latest || true
 
           devcontainer build \
-            --platform=linux/amd64 \
+            ${ADDITIONAL_BUILD_COMMANDS} \
             --image-name=${{ needs.base.outputs.docker_registry }}/${{ steps.tags.outputs.name }}:${{ needs.base.outputs.tag }} \
             --image-name=${{ needs.base.outputs.docker_registry }}/${{ steps.tags.outputs.name }}:latest \
             --workspace-folder=${{ matrix.img }}
-
-          if [ ${{ github.ref == 'refs/heads/main' }} = "true" ]; then
-            echo "Pushing images"
-
-            docker push ${{ needs.base.outputs.docker_registry }}/${{ steps.tags.outputs.name }}:${{ needs.base.outputs.tag }}
-            docker push ${{ needs.base.outputs.docker_registry }}/${{ steps.tags.outputs.name }}:latest
-          fi

--- a/images/base/.devcontainer/devcontainer.json
+++ b/images/base/.devcontainer/devcontainer.json
@@ -3,7 +3,7 @@
   "dockerFile": "Dockerfile",
   "features": {
     "ghcr.io/christophermacgown/devcontainer-features/direnv:1": {},
-    "ghcr.io/devcontainers/features/docker-outside-of-docker:1": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/eitsupi/devcontainer-features/jq-likes:1": {
       "jqVersion": "latest",
       "yqVersion": "4",


### PR DESCRIPTION

## Description
<!-- Describe your changes in detail -->

When running minikube on a Mac, the Docker binary (rightly) displays as arm64 and the host as amd64 which confuses everything. So, back to making the original multiplatform build work.


## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
