### PR TITLE
fix(tcld): prevent pollution of GOPATH by tcld build

### DIFF
--- a/src/tcld/devcontainer-feature.json
+++ b/src/tcld/devcontainer-feature.json
@@ -1,7 +1,7 @@
 {
   "name": "Temporal Cloud CLI (tcld)",
   "id": "tcld",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "A CLI tool for managing Temporal Cloud namespaces.",
   "options": {
     "git_repo": {

--- a/src/tcld/install.sh
+++ b/src/tcld/install.sh
@@ -19,6 +19,9 @@ GIT_REPO=${GIT_REPO:-"https://github.com/temporalio/tcld.git"}
 VERSION=${VERSION:-"latest"}
 TARGET_PATH=${TARGET_PATH:-"/usr/local/bin"}
 TCLD_DIR=/tmp/tcld
+# Prevent pollution of main /go dir as this is run as sudo
+GOPATH=/tmp/go
+GOCACHE=/tmp/gocache
 
 rm -rf "${TCLD_DIR}"
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
The feature runs as `sudo` which will change the `/go/pkg` folder to `root` ownership, polluting the final image.

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
