### PR TITLE
fix: change base image from deprecated vscode ubuntu image

### DIFF
--- a/images/base/.devcontainer/Dockerfile
+++ b/images/base/.devcontainer/Dockerfile
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM mcr.microsoft.com/vscode/devcontainers/base:ubuntu
+FROM mcr.microsoft.com/devcontainers/base:ubuntu
 
 USER root
 


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
Move from [deprecated image](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/ubuntu) to [new](https://github.com/devcontainers/images/tree/main/src/base-ubuntu)

These should be functionally the same

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
