### PR TITLE
fix(temporal): remove deprecated tcld from temporal images

### DIFF
--- a/images/temporal_full/.devcontainer/devcontainer.json
+++ b/images/temporal_full/.devcontainer/devcontainer.json
@@ -14,8 +14,7 @@
     },
     "ghcr.io/devcontainers/features/python:1": {},
     "ghcr.io/devcontainers/features/ruby:1": {},
-    "ghcr.io/devcontainers-extra/features/temporal-cli:1": {},
-    "ghcr.io/mrsimonemms/devcontainers/tcld:1": {}
+    "ghcr.io/devcontainers-extra/features/temporal-cli:1": {}
   },
   "containerEnv": {
     "PRE_COMMIT_HOME": "/home/vscode/.cache/pre-commit",

--- a/images/temporal_min/.devcontainer/devcontainer.json
+++ b/images/temporal_min/.devcontainer/devcontainer.json
@@ -8,8 +8,7 @@
       "package": "cruft"
     },
     "ghcr.io/devcontainers/features/python:1": {},
-    "ghcr.io/devcontainers-extra/features/temporal-cli:1": {},
-    "ghcr.io/mrsimonemms/devcontainers/tcld:1": {}
+    "ghcr.io/devcontainers-extra/features/temporal-cli:1": {}
   },
   "containerEnv": {
     "PRE_COMMIT_HOME": "/home/vscode/.cache/pre-commit",


### PR DESCRIPTION
## Description
<!-- Describe your changes in detail -->
TCLD still remains as an installable feature, but now replaced with Temporal CLI - [see forum post](https://community.temporal.io/t/announcing-end-of-support-for-tctl/17764)

## Related Issue(s)
<!-- List the issue(s) this PR solves. An issue should be raised before creating a PR -->
Fixes #

## How to test
<!-- Provide steps to test this PR -->
